### PR TITLE
feat: Alternative data centers and endpoints

### DIFF
--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -7,7 +7,18 @@ export class ClientApi extends CloudinaryApi {
   async upload (file: string, options:Object = {}, callback?: Function) {
     const $options = toSnakeCase(options)
 
-    const endpoint = `https://api.cloudinary.com/v1_1/${this.configurations.cloudName}/upload`
+    const region = this.configurations.region || null
+    let apiRegion = 'api'
+
+    switch (region) {
+      case 'europe':
+        apiRegion = 'api-eu'
+        break
+      case 'asia':
+        apiRegion = 'api-ap'
+    }
+
+    const endpoint = `https://${apiRegion}.cloudinary.com/v1_1/${this.configurations.cloudName}/upload`
 
     const request = await fetch(endpoint, {
       method: 'POST',

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -14,6 +14,7 @@ export class ClientApi extends CloudinaryApi {
         break
       case 'asia':
         apiRegion = 'api-ap'
+        break
     }
 
     const endpoint = `https://${apiRegion}.cloudinary.com/v1_1/${this.configurations.cloudName}/upload`

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -6,11 +6,9 @@ import type { CloudConfig } from '@cld-apis/types'
 export class ClientApi extends CloudinaryApi {
   async upload (file: string, options:Object = {}, callback?: Function) {
     const $options = toSnakeCase(options)
-
-    const region = this.configurations.region || null
+  
     let apiRegion = 'api'
-
-    switch (region) {
+    switch (this.configurations.region || null) {
       case 'europe':
         apiRegion = 'api-eu'
         break


### PR DESCRIPTION
Hello,

I received the following error `Error: Cloud our-name-eu belongs to eu geo, please access via api-eu.cloudinary.com`

According to the  [Cloudinary documentation](https://cloudinary.com/documentation/image_upload_api_reference#alternative_data_centers_and_endpoints_premium_feature)
> By default, Cloudinary accounts use US-based data centers. In these cases, the endpoint format is as shown at the beginning of this Overview.
> 
> If the majority of your users are located in Europe or Asia, Cloudinary can set up your account to use our Europe (EU) or Asia Pacific (AP) data center. In that case, your endpoints will take the form:
> 
> `https://api-eu.cloudinary.com/v1_1/:cloud_name/:action`
> 
> OR
> 
> `https://api-ap.cloudinary.com/v1_1/:cloud_name/:action`

The current endpoint can only access US data centers by default
https://github.com/nuxt-community/cloudinary-module/blob/ba17279f96d115f88c84aa2e737c145267fc7d90/src/runtime/client.ts#L10

---

**Proposed solution:**
Add new configuration cloudinary option called `region`  which can either be 'europe' or 'asia' otherwise leave out for default endpoint to US servers.