### PR TITLE
Fix typescript error in CldOgImage.vue

### DIFF
--- a/src/runtime/components/CldOgImage.vue
+++ b/src/runtime/components/CldOgImage.vue
@@ -122,7 +122,7 @@ const { url: twitterImageUrl } = useCldImageUrl({
 });
 
 const computedTwitterTitle = computed(
-  () => props.twitterTitle || currentRoute.meta?.title || " "
+  () => props.twitterTitle || currentRoute.value.meta?.title || " "
 );
 </script>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Fix #147

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
computedTwitterTitle in CldOgImage.vue uses currentRoute which is a ref value. To access the value, we should use currentRoute.value
Currently currentRoute.meta throws a Typescript error and it's not possible to compile the app with Typescript checks.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
