### PR TITLE
fix: cast title meta as string in CldOgImage

### DIFF
--- a/src/runtime/components/CldOgImage.vue
+++ b/src/runtime/components/CldOgImage.vue
@@ -122,7 +122,7 @@ const { url: twitterImageUrl } = useCldImageUrl({
 });
 
 const computedTwitterTitle = computed(
-  () => props.twitterTitle || currentRoute.value.meta?.title || " "
+  () => props.twitterTitle || currentRoute.value.meta?.title as string || " "
 );
 </script>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
resolve #177

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Hi :wave: This PR fix `CldOgImage` types for `vue-tsc`. Since `route.meta.title` is unknown, ts will assume that `computedTwitterTitle` is `ComputedRef<{}>` instead of `ComputedRef<string>`

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
