### PR TITLE
fix: use type imports for verbatimModuleSyntax

### DIFF
--- a/src/runtime/components/CldVideoPlayer.vue
+++ b/src/runtime/components/CldVideoPlayer.vue
@@ -3,7 +3,7 @@ import { ref } from "vue";
 import { useHead } from "@unhead/vue";
 import { useRuntimeConfig } from "#imports";
 import { parseUrl } from "@cloudinary-util/util";
-import { ConfigOptions } from "@cloudinary-util/url-loader";
+import type { ConfigOptions } from "@cloudinary-util/url-loader";
 
 export interface CloudinaryVideoPlayer {
   on: Function;

--- a/src/runtime/composables/useCldImageUrl.ts
+++ b/src/runtime/composables/useCldImageUrl.ts
@@ -1,5 +1,6 @@
 import { useRuntimeConfig } from '#imports'
-import { constructCloudinaryUrl, ConstructUrlProps } from '@cloudinary-util/url-loader'
+import { constructCloudinaryUrl } from '@cloudinary-util/url-loader'
+import type { ConstructUrlProps } from '@cloudinary-util/url-loader' 
 import nuxtPkg from 'nuxt/package.json';
 import pkg from '../../../package.json'
 

--- a/src/runtime/composables/useCldVideoUrl.ts
+++ b/src/runtime/composables/useCldVideoUrl.ts
@@ -1,5 +1,6 @@
 import { useRuntimeConfig } from '#imports'
-import { constructCloudinaryUrl, ConstructUrlProps, ConfigOptions, AnalyticsOptions, VideoOptions } from '@cloudinary-util/url-loader'
+import { constructCloudinaryUrl } from '@cloudinary-util/url-loader'
+import type { ConstructUrlProps, ConfigOptions, AnalyticsOptions, VideoOptions } from '@cloudinary-util/url-loader'
 import nuxtPkg from 'nuxt/package.json';
 import pkg from '../../../package.json'
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

Hey :wave: this PR adds type imports since verbatimModulesSyntax is enabled by default on nuxt > 3.6 
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
