### PR TITLE
fix typos in documentation

### DIFF
--- a/docs/content/1.getting-started.md
+++ b/docs/content/1.getting-started.md
@@ -40,7 +40,7 @@ CLOUDINARY_CLOUD_NAME=<YOUR_CLOUDINARY_CLOUD_NAME>
 Don't have a Cloudinary account? [Sign up](https://cloudinary.com/users/register_free?utm_campaign=devx_nuxtcloudinary&utm_medium=referral&utm_source=nuxtcloudinary) for free on cloudinary.com!
 
 ::callout{icon="i-heroicons-check-circle"}
-And that's it! You can now use Clodinary in Nuxt ✨
+And that's it! You can now use Cloudinary in Nuxt ✨
 ::
 
 ```vue

--- a/docs/content/2.components/CldImage/1.usage.md
+++ b/docs/content/2.components/CldImage/1.usage.md
@@ -84,7 +84,7 @@ Using `CldImage.vue` component is really straight forward. It accepts the same a
 />
 ```
 
-For all available configuration options, checkout the next page.
+For all available configuration options, check out the next page.
 
 ## Using Cloudinary URL's
 

--- a/docs/content/2.components/CldMediaLibrary.md
+++ b/docs/content/2.components/CldMediaLibrary.md
@@ -2,7 +2,7 @@
 description: 
 ---
 
-The CldMediaLibrary creates a media gallery element that uses an instance of the [Cloudinary Media Library Widget](https://cloudinary.com/documentation/media_library_widget?utm_campaign=devx_nuxtcloudinary&utm_medium=referral&utm_source=nuxtcloudinary) to give you an easy way to add media librarry component to your Nuxt app.
+The CldMediaLibrary creates a media gallery element that uses an instance of the [Cloudinary Media Library Widget](https://cloudinary.com/documentation/media_library_widget?utm_campaign=devx_nuxtcloudinary&utm_medium=referral&utm_source=nuxtcloudinary) to give you an easy way to add media library component to your Nuxt app.
 
 ## Basic Usage
 
@@ -35,7 +35,7 @@ CldMediaLibrary accepts several customization props listed below:
 | useSaml   | boolean | `false`    |
 | params    | object  | `{}`       |
 
-For all other available props checkout [Cloudinary Media Gallery Docs](https://cloudinary.com/documentation/media_library_widget#2_set_the_configuration_options?utm_campaign=devx_nuxtcloudinary&utm_medium=referral&utm_source=nuxtcloudinary) and make sure to pass them to the component as `params` like following:
+For all other available props check out [Cloudinary Media Gallery Docs](https://cloudinary.com/documentation/media_library_widget#2_set_the_configuration_options?utm_campaign=devx_nuxtcloudinary&utm_medium=referral&utm_source=nuxtcloudinary) and make sure to pass them to the component as `params` like following:
 
 ```vue
 <script setup lang="ts">

--- a/docs/content/2.components/CldOgImage.md
+++ b/docs/content/2.components/CldOgImage.md
@@ -4,7 +4,7 @@ description:
 
 ## Usage
 
-The CldOgImage give you the ability to use the same CldImage API to easily generate Open Graph images (or social cards) inside of Nuxt.
+The CldOgImage gives you the ability to use the same CldImage API to easily generate Open Graph images (or social cards) inside of Nuxt.
 
 ## Basic Usage
 

--- a/docs/content/2.components/CldProductGallery.md
+++ b/docs/content/2.components/CldProductGallery.md
@@ -42,7 +42,7 @@ CldProductGallery accepts several customization props listed below:
 | zoom             | boolean | `false`                                                              |
 | params           | object  | `{}`                                                                 |
 
-For all other available props checkout [Cloudinary Product Gallery Docs](https://cloudinary.com/documentation/product_gallery_reference#widget_parameters?utm_campaign=devx_nuxtcloudinary&utm_medium=referral&utm_source=nuxtcloudinary) and make sure to pass them to the component as `params` like following:
+For all other available props check out [Cloudinary Product Gallery Docs](https://cloudinary.com/documentation/product_gallery_reference#widget_parameters?utm_campaign=devx_nuxtcloudinary&utm_medium=referral&utm_source=nuxtcloudinary) and make sure to pass them to the component as `params` like following:
 
 ```vue
 <script setup lang="ts">

--- a/docs/content/2.components/CldUploadWidget.md
+++ b/docs/content/2.components/CldUploadWidget.md
@@ -38,7 +38,7 @@ Signing upload requests requires passing in an endpoint to the component.
 
 You can do this by creating a serverless function that reads the parameters as the body and returns an object with the signature.
 
-Use the following to generate an signed upload widget:
+Use the following to generate a signed upload widget:
 
 ```html
 <CldUploadWidget

--- a/docs/content/2.components/CldVideoPlayer.md
+++ b/docs/content/2.components/CldVideoPlayer.md
@@ -2,9 +2,9 @@
 description:
 ---
 
-## The usage
+## Usage
 
-The CldVideoPlayer component helps to embed Cloudinary videos using the [Cloudinary Video Player](https://cloudinary.com/documentation/cloudinary_video_player?utm_campaign=devx_nuxtcloudinary&utm_medium=referral&utm_source=nuxtcloudinary) giving you a full customizable experience for your player.
+The CldVideoPlayer component helps to embed Cloudinary videos using the [Cloudinary Video Player](https://cloudinary.com/documentation/cloudinary_video_player?utm_campaign=devx_nuxtcloudinary&utm_medium=referral&utm_source=nuxtcloudinary) giving you a fully customizable experience for your player.
 
 ## Basic Usage
 
@@ -17,7 +17,7 @@ The basic required props include `width`, `height`, and `src`:
 :cld-video-player{src="videos/mountain-stars" width="900" height="900" style="aspect-ratio: 1620 / 1080" id="1"}
 
 ::callout{icon="i-heroicons-exclamation-triangle-20-solid" color="amber"}
-Note: If you wish to display several video players with the same media on the same page (as we did in the documentation below), make sure to pass unique `id` property.
+Note: If you wish to display several video players with the same media on the same page (as we did in the documentation below), make sure to pass a unique `id` property.
 ::
 
 ## Customization
@@ -75,7 +75,7 @@ Picture-in-picture helps your viewers continue their multitasking agenda and mai
   width="600"
   height="600"
   src="<Cloudinary URL>"
-  pictureInPictureToogle
+  pictureInPictureToggle
 />
 ```
 
@@ -181,7 +181,7 @@ the [Subtitles and Captions guide](https://cloudinary.com/documentation/video_pl
 | version                | string         | `"1.10.6"` | Cloudinary Video Player version                                                                                                                                                                                                                                 | `"1.9.4"`                                          |
 | videoRef               | Ref            | -          | React ref to access video element                                                                                                                                                                                                                               | See Refs Below                                     |
 | width                  | string/number  | -          | **Required**: Player width                                                                                                                                                                                                                                      | `1920`                                             |
-| pictureInPictureToogle | boolean        | -          | Enable Picture in Picture mode                                                                                                                                                                                                                                  | true                                               |
+| pictureInPictureToggle | boolean        | -          | Enable Picture in Picture mode                                                                                                                                                                                                                                  | true                                               |
 | chaptersButton         | boolean        | -          | Enable Chapters button                                                                                                                                                                                                                                          | true                                               |
 | chapters               | object/boolean | -          | Chapters configuration                                                                                                                                                                                                                                          | { 0: 'Chapter 1', 6: 'Chapter 2', 9: 'Chapter 3' } |
 | disableRemotePlayback  | boolean        | -          | Indicate if media element may have a remote playback UI                                                                                                                                                                                                         | true                                               |

--- a/docs/content/3.composables/1.useCldImageUrl.md
+++ b/docs/content/3.composables/1.useCldImageUrl.md
@@ -6,7 +6,7 @@ This composable is using [@cloudinary-util/url-loader](https://github.com/colbyf
 
 ## Usage
 
-The composable allows you to pass optimization options and the src of the image and in return get a full cloudinary url with the optimized images. Then, you can use this url any way you like (for example in the custom image component).
+The composable allows you to pass optimization options and the src of the image and in return get a full Cloudinary url with the optimized images. Then, you can use this url any way you like (for example in the custom image component).
 
 ```vue
 <script lang="ts" setup>
@@ -122,7 +122,7 @@ All effect props are disabled by default.
 | vibrance           | bool/string   | `true`, `"70"`                                       |
 | vignette           | bool/string   | `true`, `"30"`                                       |
 
-[View the Cloudinary docs](https://cloudinary.com/documentation/transformation_reference#e_effect?utm_campaign=devx_nuxtcloudinary&utm_medium=referral&utm_source=nuxtcloudinary) to see learn more about using effects.
+[View the Cloudinary docs](https://cloudinary.com/documentation/transformation_reference#e_effect?utm_campaign=devx_nuxtcloudinary&utm_medium=referral&utm_source=nuxtcloudinary) to learn more about using effects.
 
 ### Overlay Options
 


### PR DESCRIPTION
Fix typos in documentation

This pull request fixes a few minor typos across multiple documentation files related to Cloudinary components and composables.
The changes improve clarity and consistency without affecting functionality.

These adjustments are purely editorial and do not introduce any code or logic changes.